### PR TITLE
Add function to return id_token (for Service Now)

### DIFF
--- a/src/Service.js
+++ b/src/Service.js
@@ -458,6 +458,20 @@ Service_.prototype.getAccessToken = function() {
 };
 
 /**
+ * Gets an id token for this service. This token can be used in HTTP
+ * requests to the service's endpoint. This method will throw an error if the
+ * user's access was not granted or has expired.
+ * @return {string} An id token.
+ */
+Service_.prototype.getIdToken = function() {
+  if (!this.hasAccess()) {
+    throw new Error('Access not granted or expired.');
+  }
+  var token = this.getToken();
+  return token.id_token;
+};
+
+/**
  * Resets the service, removing access and requiring the service to be
  * re-authorized.
  */


### PR DESCRIPTION
Some IDPs such as OpenAM can be configured to provide both an access_token and an id_token with the callback.  This update provides a function that can be called to return the id_token instead of the access_token.  The id_token contains a payload with claims related to the authenticated identity.  This was required for API integration to Service Now, who told me their service cannot be configured to accept an access_token.