### PR TITLE
Update example for Google OAuth2 offline access

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ function getDriveService() {
 
       // Sets the login hint, which will prevent the account chooser screen
       // from being shown to users logged in with multiple accounts.
-      // Prefer Session.getEffectiveUser().getEmail() if used in add-ons.
-      .setParam('login_hint', Session.getActiveUser().getEmail())
+      .setParam('login_hint', Session.getEffectiveUser().getEmail())
 
       // Requests offline access.
       .setParam('access_type', 'offline')
-      // This param is required to ensure a refresh token is always returned.
+      
+      // Consent prompt is required to ensure a refresh token is always
+      // returned when requesting offline access.
       .setParam('prompt', 'consent');
 }
 ```

--- a/README.md
+++ b/README.md
@@ -124,14 +124,13 @@ function getDriveService() {
 
       // Sets the login hint, which will prevent the account chooser screen
       // from being shown to users logged in with multiple accounts.
+      // Prefer Session.getEffectiveUser().getEmail() if used in add-ons.
       .setParam('login_hint', Session.getActiveUser().getEmail())
 
       // Requests offline access.
       .setParam('access_type', 'offline')
-
-      // Forces the approval prompt every time. This is useful for testing,
-      // but not desirable in a production application.
-      .setParam('approval_prompt', 'force');
+      // This param is required to ensure a refresh token is always returned.
+      .setParam('prompt', 'consent');
 }
 ```
 


### PR DESCRIPTION
Current README.md still mention approval_prompt that is not valid anymore.
Also, prompt=consent param is required in some situation (if user already approved an app) to have a refresh token returned when exchanging authorization code.

Also mentions Session.getEffectiveUser().getEmail() as an alternative to Session.getActiveUser().getEmail() in login_hint when used in add-on triggers (prevents a warning message on every execution).