### PR TITLE
Mailchimp API with Google Apps Script

### DIFF
--- a/samples/Mailchimp.gs
+++ b/samples/Mailchimp.gs
@@ -18,7 +18,7 @@ function run() {
     var storage = service.getStorage();
     var dc = storage.getValue('dc');
 
-    // Make a request to retrieve the account information.
+    // Make a request to retrieve the Mailchimp campaigns.
     var url = 'https://' + dc + '.api.mailchimp.com/3.0/campaigns/';
     var response = UrlFetchApp.fetch(url, {
       headers: {

--- a/samples/Mailchimp.gs
+++ b/samples/Mailchimp.gs
@@ -17,7 +17,7 @@ function run() {
     // Retrieve the account ID and base URI from storage.
     var storage = service.getStorage();
     var dc = storage.getValue('dc');
-    
+
     // Make a request to retrieve the account information.
     var url = 'https://' + dc + '.api.mailchimp.com/3.0/campaigns/';
     var response = UrlFetchApp.fetch(url, {
@@ -62,7 +62,7 @@ function getService() {
     .setPropertyStore(PropertiesService.getUserProperties())
 
     // Set the cache store where authorized tokens should be persisted.
-    .setCache(CacheService.getUserCache())
+    .setCache(CacheService.getUserCache());
 };
 
 /**
@@ -85,7 +85,7 @@ function authCallback(request) {
     // Store the Mailchimp datacenter for future API calls.
     var storage = service.getStorage();
     storage.setValue('dc', result.dc);
-    
+
     return HtmlService.createHtmlOutput('Success!');
   } else {
     return HtmlService.createHtmlOutput('Denied.');

--- a/samples/Mailchimp.gs
+++ b/samples/Mailchimp.gs
@@ -6,7 +6,6 @@
 
 var CLIENT_ID = '...';
 var CLIENT_SECRET = '...';
-var OAUTH_HOST = 'login.mailchimp.com';
 
 /**
  * Authorizes and makes a request to the Docusign API.
@@ -47,8 +46,8 @@ function reset() {
 function getService() {
   return OAuth2.createService('Mailchimp')
     // Set the endpoint URLs.
-    .setAuthorizationBaseUrl('https://' + OAUTH_HOST + '/oauth2/authorize')
-    .setTokenUrl('https://' + OAUTH_HOST + '/oauth2/token')
+    .setAuthorizationBaseUrl('https://login.mailchimp.com/oauth2/authorize')
+    .setTokenUrl('https://login.mailchimp.com/oauth2/token')
 
     // Set the client ID and secret.
     .setClientId(CLIENT_ID)
@@ -74,7 +73,7 @@ function authCallback(request) {
   if (authorized) {
     // Get the user info to determine the data center needed for
     // future requests.
-    var url = 'https://' + OAUTH_HOST + '/oauth2/metadata';
+    var url = 'https://login.mailchimp.com/oauth2/metadata';
     var response = UrlFetchApp.fetch(url, {
       headers: {
         Authorization: 'Bearer ' + service.getAccessToken()

--- a/samples/Mailchimp.gs
+++ b/samples/Mailchimp.gs
@@ -1,0 +1,100 @@
+/*
+ * This sample demonstrates how to configure the library for the Mailchimp API.
+ * Instructions on how to generate OAuth credentuals is available here:
+ * https://mailchimp.com/developer/guides/how-to-use-oauth2/#Step_1%3A_Register_your_application
+ */
+
+var CLIENT_ID = '...';
+var CLIENT_SECRET = '...';
+var OAUTH_HOST = 'login.mailchimp.com';
+
+/**
+ * Authorizes and makes a request to the Docusign API.
+ */
+function run() {
+  var service = getService();
+  if (service.hasAccess()) {
+    // Retrieve the account ID and base URI from storage.
+    var storage = service.getStorage();
+    var dc = storage.getValue('dc');
+    
+    // Make a request to retrieve the account information.
+    var url = 'https://' + dc + '.api.mailchimp.com/3.0/campaigns/';
+    var response = UrlFetchApp.fetch(url, {
+      headers: {
+        Authorization: 'Bearer ' + service.getAccessToken()
+      }
+    });
+    var result = JSON.parse(response.getContentText());
+    Logger.log(JSON.stringify(result, null, 2));
+  } else {
+    var authorizationUrl = service.getAuthorizationUrl();
+    Logger.log('Open the following URL and re-run the script: %s',
+        authorizationUrl);
+  }
+}
+
+/**
+ * Reset the authorization state, so that it can be re-tested.
+ */
+function reset() {
+  getService().reset();
+}
+
+/**
+ * Configures the service.
+ */
+function getService() {
+  return OAuth2.createService('Mailchimp')
+    // Set the endpoint URLs.
+    .setAuthorizationBaseUrl('https://' + OAUTH_HOST + '/oauth2/authorize')
+    .setTokenUrl('https://' + OAUTH_HOST + '/oauth2/token')
+
+    // Set the client ID and secret.
+    .setClientId(CLIENT_ID)
+    .setClientSecret(CLIENT_SECRET)
+
+    // Set the name of the callback function that should be invoked to
+    // complete the OAuth flow.
+    .setCallbackFunction('authCallback')
+
+    // Set the property store where authorized tokens should be persisted.
+    .setPropertyStore(PropertiesService.getUserProperties())
+
+    // Set the cache store where authorized tokens should be persisted.
+    .setCache(CacheService.getUserCache())
+};
+
+/**
+ * Handles the OAuth callback.
+ */
+function authCallback(request) {
+  var service = getService();
+  var authorized = service.handleCallback(request);
+  if (authorized) {
+    // Get the user info to determine the data center needed for
+    // future requests.
+    var url = 'https://' + OAUTH_HOST + '/oauth2/metadata';
+    var response = UrlFetchApp.fetch(url, {
+      headers: {
+        Authorization: 'Bearer ' + service.getAccessToken()
+      }
+    });
+    var result = JSON.parse(response.getContentText());
+
+    // Store the Mailchimp datacenter for future API calls.
+    var storage = service.getStorage();
+    storage.setValue('dc', result.dc);
+    
+    return HtmlService.createHtmlOutput('Success!');
+  } else {
+    return HtmlService.createHtmlOutput('Denied.');
+  }
+}
+
+/**
+ * Logs the redict URI to register in the Mailchimp application settings.
+ */
+function logRedirectUri() {
+  Logger.log(OAuth2.getRedirectUri());
+}


### PR DESCRIPTION
I have included support for Mailchimp in my [Mail Merge with Attachments](https://gsuite.google.com/marketplace/app/mail_merge_with_attachments/223404411203) add-on for Gmail using the OAuth2 Library for Google Apps Script.

To get started, create your own set of credentials from your Mailchimp account as described [here](https://mailchimp.com/developer/guides/how-to-use-oauth2/#Step_1%3A_Register_your_application).

- In your Mailchimp account, navigate to the Account page.
- In the drop-down menu, select Extras, and then Registered Apps.
- Click Register an App.
- In the appropriate fields, enter your application information and click Create.

![Screenshot 2020-02-23 at 2 07 49 PM](https://user-images.githubusercontent.com/1344071/75106784-003e3e00-5646-11ea-95c4-d62fb34086a2.png)

