### PR TITLE
Don't require token storage in properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ function getDriveService() {
 
       // Requests offline access.
       .setParam('access_type', 'offline')
-      
+
       // Consent prompt is required to ensure a refresh token is always
       // returned when requesting offline access.
       .setParam('prompt', 'consent');
@@ -214,6 +214,36 @@ function logout() {
 ```
 
 ## Best practices
+
+### Token storage
+
+In almost all cases you'll want to persist the OAuth tokens after you retrieve
+them. This prevents having to request access from the user every time you want
+to call the API. To do so, make sure you set a properties store when you define
+your service:
+
+```js
+return OAuth2.createService('Foo')
+    .setPropertyStore(PropertiesService.getUserProperties())
+    // ...
+```
+
+Apps Script has [property stores][property_stores] scoped to the user, script,
+or document. In most cases you'll want to choose user-scoped properties, as it
+is most common to have each user of your script authorize access to their own
+account. However there are uses cases where you'd want to authorize access to
+a shared resource and then have all users of the script (or on the same
+document) share that access.
+
+When using a service account or 2-legged OAuth flow, where users aren't prompted
+for authorization, storing tokens is still beneficial as there can be rate
+limits on generating new tokens. However there are edge cases where you need to
+generate lots of different tokens in a short amount of time, and persisting
+those tokens to properties can exceed your `PropertiesService` quota. In those
+cases you can omit any form of token storage and just retrieve new ones as
+needed.
+
+[property_stores]: https://developers.google.com/apps-script/reference/properties/properties-service
 
 ### Caching
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5900,6 +5900,12 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5937,12 +5943,6 @@
         "es-abstract": "1.13.0",
         "function-bind": "1.1.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/src/Service.js
+++ b/src/Service.js
@@ -607,9 +607,6 @@ Service_.prototype.refresh = function() {
  * @return {Storage} The service's storage.
  */
 Service_.prototype.getStorage = function() {
-  validate_({
-    'Property store': this.propertyStore_
-  });
   if (!this.storage_) {
     var prefix = 'oauth2.' + this.serviceName_;
     this.storage_ = new Storage_(prefix, this.propertyStore_, this.cache_);

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -21,14 +21,14 @@
  * related information.
  * @param {string} prefix The prefix to use for keys in the properties and
  *     cache.
- * @param {PropertiesService.Properties} properties The properties instance to
- *     use.
+ * @param {PropertiesService.Properties} optProperties The optional properties
+ *     instance to use.
  * @param {CacheService.Cache} [optCache] The optional cache instance to use.
  * @constructor
  */
-function Storage_(prefix, properties, optCache) {
+function Storage_(prefix, optProperties, optCache) {
   this.prefix_ = prefix;
-  this.properties_ = properties;
+  this.properties_ = optProperties;
   this.cache_ = optCache;
   this.memory_ = {};
 }
@@ -80,7 +80,8 @@ Storage_.prototype.getValue = function(key, optSkipMemoryCheck) {
   }
 
   // Check properties.
-  if (jsonValue = this.properties_.getProperty(prefixedKey)) {
+  if (this.properties_ &&
+      (jsonValue = this.properties_.getProperty(prefixedKey))) {
     if (this.cache_) {
       this.cache_.put(prefixedKey,
           jsonValue, Storage_.CACHE_EXPIRATION_TIME_SECONDS);
@@ -108,7 +109,9 @@ Storage_.prototype.getValue = function(key, optSkipMemoryCheck) {
 Storage_.prototype.setValue = function(key, value) {
   var prefixedKey = this.getPrefixedKey_(key);
   var jsonValue = JSON.stringify(value);
-  this.properties_.setProperty(prefixedKey, jsonValue);
+  if (this.properties_) {
+    this.properties_.setProperty(prefixedKey, jsonValue);
+  }
   if (this.cache_) {
     this.cache_.put(prefixedKey, jsonValue,
         Storage_.CACHE_EXPIRATION_TIME_SECONDS);
@@ -122,7 +125,9 @@ Storage_.prototype.setValue = function(key, value) {
  */
 Storage_.prototype.removeValue = function(key) {
   var prefixedKey = this.getPrefixedKey_(key);
-  this.properties_.deleteProperty(prefixedKey);
+  if (this.properties_) {
+    this.properties_.deleteProperty(prefixedKey);
+  }
   if (this.cache_) {
     this.cache_.remove(prefixedKey);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,12 @@ describe('Service', function() {
       assert.equal(cache.counter, cacheStart);
       assert.equal(properties.counter, propertiesStart);
     });
+
+    it('should not fail if no properties are set',
+        function() {
+      var service = OAuth2.createService('test');
+      service.getToken();
+    })
   });
 
   describe('#saveToken_()', function() {
@@ -159,6 +165,15 @@ describe('Service', function() {
       assert.deepEqual(JSON.parse(cache.get(key)), token);
       assert.deepEqual(JSON.parse(properties.getProperty(key)), token);
     });
+
+    it('should not fail if no properties are set',
+        function() {
+      var service = OAuth2.createService('test');
+      var token = {
+        access_token: 'foo'
+      };
+      service.saveToken_(token);
+    })
   });
 
   describe('#reset()', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,7 @@ describe('Service', function() {
         function() {
       var service = OAuth2.createService('test');
       service.getToken();
-    })
+    });
   });
 
   describe('#saveToken_()', function() {
@@ -173,7 +173,7 @@ describe('Service', function() {
         access_token: 'foo'
       };
       service.saveToken_(token);
-    })
+    });
   });
 
   describe('#reset()', function() {


### PR DESCRIPTION
There are use cases where persisting tokens isn't required, and doing so exceeds the `PropertiesService` write quota. Permit services which don't set a properties store, and update the README to clarify the usage.

Fixes #217.