### PR TITLE
Add non-nullable modifier to return type of functions never returning null

### DIFF
--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -51,7 +51,7 @@ function validate_(params) {
 /**
  * Gets the time in seconds, rounded down to the nearest second.
  * @param {Date} date The Date object to convert.
- * @return {Number} The number of seconds since the epoch.
+ * @return {number} The number of seconds since the epoch.
  * @private
  */
 function getTimeInSeconds_(date) {


### PR DESCRIPTION
Alternatively, use a primitive type instead of nullable boxed type.