### PR TITLE
Remove all values from storage when the service is reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "del": "^1.2.1",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
-    "fibers": "^2.0.2",
+    "fibers": "^4.0.2",
     "gas-local": "^1.3.1",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",

--- a/src/Service.js
+++ b/src/Service.js
@@ -476,7 +476,7 @@ Service_.prototype.getIdToken = function() {
  * re-authorized.
  */
 Service_.prototype.reset = function() {
-  this.getStorage().removeValue(null);
+  this.getStorage().reset();
 };
 
 /**

--- a/test/mocks/properties.js
+++ b/test/mocks/properties.js
@@ -16,4 +16,8 @@ MockProperties.prototype.deleteProperty = function(key) {
   delete this.store[key];
 };
 
+MockProperties.prototype.getProperties = function() {
+  return Object.assign({}, this.store);
+};
+
 module.exports = MockProperties;

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,46 @@ describe('Service', function() {
       assert.notExists(cache.get(key));
       assert.notExists(properties.getProperty(key));
     });
+
+    it('should delete values in storage', function() {
+      var cache = new MockCache();
+      var properties = new MockProperties();
+      var service = OAuth2.createService('test')
+          .setPropertyStore(properties)
+          .setCache(cache);
+      var storage = service.getStorage();
+      storage.setValue('foo', 'bar');
+
+      service.reset();
+
+      assert.notExists(storage.getValue('foo'));
+    });
+
+    it('should not delete values from other services', function() {
+      var cache = new MockCache();
+      var properties = new MockProperties();
+      var service = OAuth2.createService('test')
+          .setPropertyStore(properties)
+          .setCache(cache);
+      var values = {
+        'oauth2.something': 'token',
+        'oauth2.something.foo': 'bar',
+        'oauth2.something.test': 'baz',
+        'oauth2.testing': 'token',
+        'oauth2.testing.foo': 'bar',
+      };
+      for (let [key, value] of Object.entries(values)) {
+        properties.setProperty(key, value);
+        cache.put(key, value);
+      }
+
+      service.reset();
+
+      for (let [key, value] of Object.entries(values)) {
+        assert.equal(cache.get(key), value);
+        assert.equal(properties.getProperty(key), value);
+      }
+    });
   });
 
   describe('#hasAccess()', function() {


### PR DESCRIPTION
Also changed the in-memory storage to use prefixed keys, to be consistent with properties and cache (since it caused me a lot of confusion while developing this feature). Fixes #229.